### PR TITLE
Optimize elog

### DIFF
--- a/format.go
+++ b/format.go
@@ -229,3 +229,23 @@ func (f *BaseFormatter) AddFuncMap(funcMap template.FuncMap) {
 func (f *BaseFormatter) Paint(lv LevelType, s string) string {
 	return painter(levelColor[lv], s)
 }
+
+func (f *BaseFormatter) Datetime(r Record) string {
+	return f._datetime(r)
+}
+
+func (f *BaseFormatter) Level(r Record) string {
+	return f._level(r)
+}
+
+func (f *BaseFormatter) Name(r Record) string {
+	return f._name(r)
+}
+
+func (f *BaseFormatter) Pid(r Record) string {
+	return f._pid(r)
+}
+
+func (f *BaseFormatter) AppID(r Record) string {
+	return f._appID(r)
+}

--- a/format.go
+++ b/format.go
@@ -230,22 +230,27 @@ func (f *BaseFormatter) Paint(lv LevelType, s string) string {
 	return painter(levelColor[lv], s)
 }
 
+// Datetime dump datetime to string
 func (f *BaseFormatter) Datetime(r Record) string {
 	return f._datetime(r)
 }
 
+// Level dump level to string
 func (f *BaseFormatter) Level(r Record) string {
 	return f._level(r)
 }
 
+// Name dump name to string
 func (f *BaseFormatter) Name(r Record) string {
 	return f._name(r)
 }
 
+// Pid dump pid to string
 func (f *BaseFormatter) Pid(r Record) string {
 	return f._pid(r)
 }
 
+// AppID dump appid to string
 func (f *BaseFormatter) AppID(r Record) string {
 	return f._appID(r)
 }

--- a/record.go
+++ b/record.go
@@ -13,6 +13,7 @@ type Record interface {
 	Now() time.Time
 	Name() string
 	Fileline() string
+	String() string
 }
 
 // RecordFactory represents a factory of record.

--- a/rpc/elog_format.go
+++ b/rpc/elog_format.go
@@ -11,15 +11,15 @@ const (
 	NexSyslog
 )
 
-// ELogForamtter is the formatter for elog.
-type ELogForamtter struct {
+// ELogFormatter is the formatter for elog.
+type ELogFormatter struct {
 	*log.BaseFormatter
 	logType int
 }
 
 // NewELogFormatter create a ELogFormatter with colored.
-func NewELogFormatter(logType int, colored bool) *ELogForamtter {
-	ef := new(ELogForamtter)
+func NewELogFormatter(logType int, colored bool) *ELogFormatter {
+	ef := new(ELogFormatter)
 	ef.BaseFormatter = log.NewBaseFormatter(colored)
 	ef.SetColored(colored)
 	ef.logType = logType
@@ -27,7 +27,7 @@ func NewELogFormatter(logType int, colored bool) *ELogForamtter {
 }
 
 // Format formats a Record with set format
-func (f *ELogForamtter) Format(record log.Record) []byte {
+func (f *ELogFormatter) Format(record log.Record) []byte {
 	var result string
 
 	switch f.logType {
@@ -56,7 +56,7 @@ func (f *ELogForamtter) Format(record log.Record) []byte {
 	return []byte(result)
 }
 
-func (f *ELogForamtter) _rpcID(r *ELogRecord) string {
+func (f *ELogFormatter) _rpcID(r *ELogRecord) string {
 	s := r.rpcID
 	if s == "" {
 		s = "-"
@@ -67,7 +67,7 @@ func (f *ELogForamtter) _rpcID(r *ELogRecord) string {
 	return s
 }
 
-func (f *ELogForamtter) _requestID(r *ELogRecord) string {
+func (f *ELogFormatter) _requestID(r *ELogRecord) string {
 	s := r.requestID
 	if s == "" {
 		s = "-"

--- a/rpc/elog_format.go
+++ b/rpc/elog_format.go
@@ -7,7 +7,9 @@ import (
 )
 
 const (
+	// NexLog select elog type to nex log
 	NexLog = iota
+	// NexSyslog select elog type to nex syslog
 	NexSyslog
 )
 
@@ -33,7 +35,7 @@ func (f *ELogFormatter) Format(record log.Record) []byte {
 	switch f.logType {
 	case NexLog:
 		result = fmt.Sprintf(
-			"%v %v %v[%v]: [%v %v %v] ## %v",
+			"%v %v %v[%v]: [%v %v %v] ## %v\n",
 			f.Datetime(record),
 			f.Level(record),
 			f.Name(record),
@@ -45,7 +47,7 @@ func (f *ELogFormatter) Format(record log.Record) []byte {
 		)
 	case NexSyslog:
 		result = fmt.Sprintf(
-			"[%v %v %v] ## %v",
+			"[%v %v %v] ## %v\n",
 			f.AppID(record),
 			f._rpcID(record.(*ELogRecord)),
 			f._requestID(record.(*ELogRecord)),
@@ -76,4 +78,9 @@ func (f *ELogFormatter) _requestID(r *ELogRecord) string {
 		s = f.Paint(r.Level(), s)
 	}
 	return s
+}
+
+// ParseFormat do not need parse any more, patch this method.
+func (f *ELogFormatter) ParseFormat(format string) error {
+	return nil
 }

--- a/rpc/elog_test.go
+++ b/rpc/elog_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	NexLogPattern    = `(\d{4}-\d{2}-\d{2} \d{1,}:\d{1,}:\d{1,}.\d{0,}) info (\S+)\[(\S+)\]: \[(\S+) (.*)\] (.*)## (.+)$`
-	NexSyslogPattern = `\[(\S+) (.*)\] (.*)## (.+)$`
+	NexLogPattern    = `(\d{4}-\d{2}-\d{2} \d{1,}:\d{1,}:\d{1,}.\d{0,}) info (\S+)\[(\S+)\]: \[(\S+) (.*)\] (.*)## (.+)\n$`
+	NexSyslogPattern = `\[(\S+) (.*)\] (.*)## (.+)\n$`
 )
 
 func TestELogFormatter(t *testing.T) {

--- a/syslog/syslog_test.go
+++ b/syslog/syslog_test.go
@@ -2,6 +2,7 @@ package syslog
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -14,7 +15,7 @@ func TestSyslogtpl(t *testing.T) {
 
 	l := log.NewWithWriter("name", nil)
 
-	f := rpc.NewELogFormatter(false)
+	f := rpc.NewELogFormatter(rpc.NexSyslog, false)
 	if err := f.ParseFormat(log.TplSyslog); err != nil {
 		t.Error(err)
 		return
@@ -31,6 +32,7 @@ func TestSyslogtpl(t *testing.T) {
 	l.Info("TEST_TEST")
 
 	strs := strings.Split(buf.String(), " ")
+	fmt.Println(strs[4])
 
 	if strs[0] != "[samaritan.test" || strs[4] != "TEST_TEST\n" ||
 		strs[1] != "-" || strs[2] != "-]" {

--- a/syslog/syslog_test.go
+++ b/syslog/syslog_test.go
@@ -2,7 +2,6 @@ package syslog
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -32,7 +31,6 @@ func TestSyslogtpl(t *testing.T) {
 	l.Info("TEST_TEST")
 
 	strs := strings.Split(buf.String(), " ")
-	fmt.Println(strs[4])
 
 	if strs[0] != "[samaritan.test" || strs[4] != "TEST_TEST\n" ||
 		strs[1] != "-" || strs[2] != "-]" {


### PR DESCRIPTION
由于是固定格式的 elog 所以可以避免使用模板, 直接拼接就好了.